### PR TITLE
Close OkHttp response body in batch send, Fixes #11

### DIFF
--- a/src/main/java/com/brsanthu/googleanalytics/httpclient/OkHttpClientImpl.java
+++ b/src/main/java/com/brsanthu/googleanalytics/httpclient/OkHttpClientImpl.java
@@ -156,10 +156,10 @@ public class OkHttpClientImpl implements HttpClient {
         try {
 
             Response okResp = client.newCall(request).execute();
-            if (logger.isDebugEnabled()) logger.debug("post() response code/success: " + okResp.code() + " / " + okResp.isSuccessful());
+            if (logger.isDebugEnabled()) logger.debug("postBatch() response code/success: " + okResp.code() + " / " + okResp.isSuccessful());
 
             resp.setStatusCode(okResp.code());
-
+            okResp.close(); // this marks the response as consumed, and allows the connection to be re-used
         } catch (Exception e) {
             logger.warn("OkHttpClientImpl.post()/OkHttpClient.newCall() error", e);
         }


### PR DESCRIPTION
Correctly close the OkHttp response so connection re-use works (now it appears much faster than OkHttp, not just on par, in testing)

Also correct a debug logging comment so it is clear it was postBatch() not post()