### PR TITLE
Correctly disable doclint for maven-javadoc 3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,9 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.0.1</version>
                 <configuration>
-                    <excludePackageNames>*.internal.*</excludePackageNames>
+                    <!--  <excludePackageNames>*.internal.*</excludePackageNames> -->
                     <failOnError>false</failOnError>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/com/brsanthu/googleanalytics/GoogleAnalyticsConfig.java
+++ b/src/main/java/com/brsanthu/googleanalytics/GoogleAnalyticsConfig.java
@@ -68,7 +68,7 @@ public class GoogleAnalyticsConfig {
      * Please make sure you also enable the discovery using {@link #setDiscoverRequestParameters(boolean)}
      *
      * @param requestParameterDiscoverer can be null and is so, parameters will not be discovered.
-     * @return
+     * @return GoogleAnalyticsConfig with requestParameterDiscoverer set
      */
     public GoogleAnalyticsConfig setRequestParameterDiscoverer(RequestParameterDiscoverer requestParameterDiscoverer) {
         this.requestParameterDiscoverer = requestParameterDiscoverer;
@@ -85,7 +85,7 @@ public class GoogleAnalyticsConfig {
      * {@link GoogleAnalyticsImpl#getStats()}
      *
      * @param gatherStats
-     * @return
+     * @return GoogleAnalyticsConfig with gatherStats set
      */
     public GoogleAnalyticsConfig setGatherStats(boolean gatherStats) {
         this.gatherStats = gatherStats;

--- a/src/main/java/com/brsanthu/googleanalytics/internal/GoogleAnalyticsImpl.java
+++ b/src/main/java/com/brsanthu/googleanalytics/internal/GoogleAnalyticsImpl.java
@@ -214,7 +214,7 @@ public class GoogleAnalyticsImpl implements GoogleAnalytics, GoogleAnalyticsExec
      * Processes the custom dimensions and adds the values to list of parameters, which would be posted to GA.
      *
      * @param request
-     * @param postParms
+     * @param req
      */
     protected void processCustomDimensionParameters(GoogleAnalyticsRequest<?> request, HttpRequest req) {
         Map<String, String> customDimParms = new HashMap<String, String>();
@@ -236,7 +236,7 @@ public class GoogleAnalyticsImpl implements GoogleAnalytics, GoogleAnalyticsExec
      * Processes the custom metrics and adds the values to list of parameters, which would be posted to GA.
      *
      * @param request
-     * @param postParms
+     * @param req
      */
     protected void processCustomMetricParameters(GoogleAnalyticsRequest<?> request, HttpRequest req) {
         Map<String, String> customMetricParms = new HashMap<String, String>();

--- a/src/main/java/com/brsanthu/googleanalytics/request/DefaultRequest.java
+++ b/src/main/java/com/brsanthu/googleanalytics/request/DefaultRequest.java
@@ -54,7 +54,7 @@ import com.brsanthu.googleanalytics.internal.GoogleAnalyticsImpl;
 /**
  * Default request that captures default value for any of the parameters. Create an instance of this object and specify
  * as constructor parameter to {@link GoogleAnalyticsImpl} or set one any time using
- * {@link GoogleAnalyticsImpl#setDefaultRequest(DefaultRequest)} method.
+ * GoogleAnalyticsBuilder#withDefaultRequest(DefaultRequest) method.
  *
  * @author Santhosh Kumar
  */

--- a/src/main/java/com/brsanthu/googleanalytics/request/GoogleAnalyticsRequest.java
+++ b/src/main/java/com/brsanthu/googleanalytics/request/GoogleAnalyticsRequest.java
@@ -103,7 +103,7 @@ public class GoogleAnalyticsRequest<T> {
      *
      * @param parameter
      * @param value
-     * @return
+     * @return this - with parameter set or cleared
      */
     protected T setString(GoogleAnalyticsParameter parameter, String value) {
         if (value == null) {
@@ -652,7 +652,7 @@ public class GoogleAnalyticsRequest<T> {
      * </div>
      *
      * @param value
-     * @return
+     * @return this - with USER_ID parameter set
      */
     public T userId(String value) {
         setString(USER_ID, value);


### PR DESCRIPTION
maven-javadoc-plugin uses a different syntax for javadoc issues now, upgraded POM to reflect that

Also fixed a few of them (but not all)

Fixes #10 